### PR TITLE
SPSSWriter: Fix value of $sysmis.

### DIFF
--- a/SPSSWriter.php
+++ b/SPSSWriter.php
@@ -28,7 +28,7 @@ class SPSSWriter
 	public $compression = 0; // compression bias
 	public $numberOfCases = 1;
 	public $machineCode = 720;
-	public $sysmis = -0xFFFFFFFFFFFFEFFF; // sysmis
+	public $sysmis = -0x1fffffffffffff * 2.0**971;
 	// public $sysmis = -1.79769313486E+308; // sysmis
 	public $variables = array();
 	public $documents = array();


### PR DESCRIPTION
$sysmis is supposed to be a floating-point value that, when written to an
SPSS system file, represents the system-missing value.  The previous value
was incorrect: when written to a system file, it yielded the bytes
fe ff ff ff ff ff ef c3, instead of the correct bytes
ff ff ff ff ff ff ef ff.  This was because of the difference between
integer and floating point: when -0xFFFFFFFFFFFFEFFF is converted to an
IEEE-754 "double", the bit representation changes.  This commit corrects
the problem, as can be observed by running test_write.php and observing
the bytes written in the machine floating point record at offset 0xb40.