### PR TITLE
Fix Non String Value Mapping

### DIFF
--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -212,7 +212,7 @@ class Writer
                 $this->data->matrix[$case][$idx] = $value;
             }
 
-            $nominalIdx += Utils::widthToOcts($var->width);
+            $nominalIdx += Utils::widthToOcts($variable->width);
         }
 
         $this->header->nominalCaseSize = $nominalIdx;


### PR DESCRIPTION
Not sure if this is an issue in other SPSS versions. 

Currently in SPSS 25.0.0.2, if a Numeric type Variable is created, Value Labels created with the variable cause SPSS to crash on file load.

This fixes it so that the Index for each Value Label on numeric type variables can be mapped correctly without causing the program to crash after loading the file.