### PR TITLE
Fixed incorrect padding of opcodes

### DIFF
--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -276,7 +276,7 @@ class Data extends Record
             foreach ($this->opcodes as $opc) {
                 $buffer->write(chr($opc));
             }
-            $padding = max(8 - count($this->opcodes), 0);
+            $padding = 8 - count($this->opcodes) % 8;
             for ($i = 0; $i < $padding; $i++) {
                 $buffer->write(chr(self::OPCODE_NOP));
             }


### PR DESCRIPTION
Having 0 opcodes (for example because compression is disabled), incorrectly caused 8 characters of padding instead of 0.