### PR TITLE
[FIX] Write the very-long data in segments also for uncompressed files.

### DIFF
--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -250,7 +250,6 @@ class Data extends Record
                     }
                 } else {
                     if (! $compressed) {
-                        $width = isset($veryLongStrings[$var->name]) ? $veryLongStrings[$var->name] : $width;
                         $buffer->writeString($value, Utils::roundUp($width, 8));
                     } else {
                         $offset = 0;

--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -250,7 +250,22 @@ class Data extends Record
                     }
                 } else {
                     if (! $compressed) {
-                        $buffer->writeString($value, Utils::roundUp($width, 8));
+                        $offset = 0;
+                        $width = isset($veryLongStrings[$var->name]) ? $veryLongStrings[$var->name] : $width;
+                        $segmentsCount = Utils::widthToSegments($width);
+                        for ($s = 0; $s < $segmentsCount; $s++) {
+                            $segWidth = Utils::segmentAllocWidth($width, $s);
+                            for ($i = $segWidth; $i > 0; $i -= 8) {
+                                if ($segWidth == 255) {
+                                    $chunkSize = min($i, 8);
+                                } else {
+                                    $chunkSize = 8;
+                                }
+                                $val = substr($value, $offset, $chunkSize);  // Read 8 byte segements, don't use mbsubstr here
+                                $dataBuffer->writeString($val, 8);
+                                $offset += $chunkSize;
+                            }
+                        }
                     } else {
                         $offset = 0;
                         $width = isset($veryLongStrings[$var->name]) ? $veryLongStrings[$var->name] : $width;

--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -250,6 +250,7 @@ class Data extends Record
                     }
                 } else {
                     if (! $compressed) {
+                        $width = isset($veryLongStrings[$var->name]) ? $veryLongStrings[$var->name] : $width;
                         $buffer->writeString($value, Utils::roundUp($width, 8));
                     } else {
                         $offset = 0;

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -215,7 +215,7 @@ class Writer
                 $this->data->matrix[$case][$idx] = $value;
             }
 
-            $nominalIdx += Utils::widthToOcts($var->width);
+            $nominalIdx += Utils::widthToOcts($variable->width);
         }
 
         $this->header->nominalCaseSize = $nominalIdx;


### PR DESCRIPTION
Very-long data need to be written in segments even if bytecode compression is not enabled.

This may be the issue also behind #24 