### PR TITLE
Fixed really long strings

### DIFF
--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -93,9 +93,6 @@ class Data extends Record
                 $isNumeric = $var->width == 0;
                 $width = isset($var->write[2]) ? $var->write[2] : $var->width;
 
-                // var_dump($var);
-                // exit;
-
                 if ($isNumeric) {
                     if (! $compressed) {
                         $this->matrix[$case][$varNum] = $buffer->readDouble();

--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -133,14 +133,14 @@ class Data extends Record
                         if ($opcode === self::OPCODE_NOP || $opcode === self::OPCODE_EOF) {
                             // If next segments are empty too, skip
                             $continue;
-                        }                        
+                        }
                         for ($i = $segWidth; $i > 0; $i -= 8) {
-                            if ($segWidth = 255) {
+                            if ($segWidth == 255) {
                                 $chunkSize = min($i, 8);
                             } else {
                                 $chunkSize = 8;
                             }
-                            
+
                             $val = '';
                             if (! $compressed) {
                                 $val = $buffer->readString(8);
@@ -213,7 +213,7 @@ class Data extends Record
 
         /** @var Record\Info[] $info */
         $info = $buffer->context->info;
-        
+
         $veryLongStrings = [];
         if (isset($info[Record\Info\VeryLongString::SUBTYPE])) {
             $veryLongStrings = $info[Record\Info\VeryLongString::SUBTYPE]->toArray();
@@ -224,7 +224,7 @@ class Data extends Record
         } else {
             $sysmis = NAN;
         }
-        
+
         $dataBuffer = Buffer::factory('', ['memory' => true]);
 
         for ($case = 0; $case < $casesCount; $case++) {
@@ -258,7 +258,7 @@ class Data extends Record
                         for ($s = 0; $s < $segmentsCount; $s++) {
                             $segWidth = Utils::segmentAllocWidth($width, $s);
                             for ($i = $segWidth; $i > 0; $i -= 8) {
-                                if ($segWidth = 255) {
+                                if ($segWidth == 255) {
                                     $chunkSize = min($i, 8);
                                 } else {
                                     $chunkSize = 8;
@@ -272,7 +272,7 @@ class Data extends Record
                                 }
                                 $offset += $chunkSize;
                             }
-                        }                        
+                        }
                     }
                 }
             }

--- a/src/Sav/Record/Info/VeryLongString.php
+++ b/src/Sav/Record/Info/VeryLongString.php
@@ -31,7 +31,7 @@ class VeryLongString extends Info
         if ($this->data) {
             $data = [];
             foreach ($this->data as $key => $value) {
-                $data[] = sprintf('%s=%05d%c', $key, $value, 0);
+                $data[] = sprintf('%s=%d%c', $key, $value, 0);
             }
             $data = join(self::DELIMITER, $data);
             $this->dataCount = strlen($data);

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -218,7 +218,7 @@ class Variable extends Record
     {
         // TODO: refactory
         $name = $this->name;
-        $name = mb_substr($name, 0, 6);
+        $name = mb_substr($name, 0, 5);
         $name .=  $seg;
 
         return mb_strtoupper($name);

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -120,8 +120,8 @@ class Writer
             $variable = new Record\Variable();
 
             // TODO: refactory - keep 7 positions so we can add after that for 100 very long string segments
-            $variable->name = 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
-            // $variable->name = strtoupper($var->name);
+            //$variable->name = 'V' . str_pad($idx + 1, 4, 0, STR_PAD_LEFT);
+            $variable->name = substr(strtoupper($var->name),0,8);
 
             // TODO: test
             if ($var->format == Variable::FORMAT_TYPE_A) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -205,7 +205,7 @@ class Utils
             return $width;
         }
 
-        return $segment < $segmentCount - 1 ? Variable::REAL_VLS_CHUNK : $width - $segment * Variable::EFFECTIVE_VLS_CHUNK;
+        return $segment < $segmentCount - 1 ? Variable::REAL_VLS_CHUNK : self::roundUp($width - $segment * Variable::EFFECTIVE_VLS_CHUNK, 8);
     }
 
     /**

--- a/tests/LongStringTest.php
+++ b/tests/LongStringTest.php
@@ -22,8 +22,21 @@ class LongStringTest extends TestCase
             ],
             'variables' => [
                 [
-                    'name'   => 'long',
-                    'label'  => 'long label',
+                    'name'   => 'LONGER1',
+                    'label'  => 'long label1',
+                    'width'  => 3000,
+                    'format' => Variable::FORMAT_TYPE_A,
+                    'attributes' => [
+                        '$@Role' => Variable::ROLE_INPUT,
+                    ],
+                    'data' => [
+                        $firstLong,
+                        $secondLong
+                    ]
+                ],
+                [
+                    'name'   => 'LONGER2',
+                    'label'  => 'long label2',
                     'width'  => 3000,
                     'format' => Variable::FORMAT_TYPE_A,
                     'attributes' => [
@@ -53,6 +66,7 @@ class LongStringTest extends TestCase
 
         // Uncomment if you want to really save and check the resulting file in SPSS
         //$writer->save('longString.sav');
+
         $buffer = $writer->getBuffer();
         $buffer->rewind();
         
@@ -60,8 +74,10 @@ class LongStringTest extends TestCase
         
         $expected[0][0] = $data['variables'][0]['data'][0];
         $expected[0][1] = $data['variables'][1]['data'][0];
+        $expected[0][2] = $data['variables'][2]['data'][0];
         $expected[1][0] = $data['variables'][0]['data'][1];
         $expected[1][1] = $data['variables'][1]['data'][1];
+        $expected[1][2] = $data['variables'][2]['data'][1];
         $this->assertEquals($expected, $reader->data);
     }
 

--- a/tests/LongStringTest.php
+++ b/tests/LongStringTest.php
@@ -11,8 +11,8 @@ class LongStringTest extends TestCase
 
     public function testLongString()
     {
-        $firstLong = str_repeat('1234567890', 30);
-        $secondLong = str_repeat('abcdefghij', 30);
+        $firstLong = str_repeat('1234567890', 300);
+        $secondLong = str_repeat('abcdefghij', 300);
         $data   = [
             'header'    => [
                 'prodName'     => '@(#) IBM SPSS STATISTICS',
@@ -24,7 +24,7 @@ class LongStringTest extends TestCase
                 [
                     'name'   => 'long',
                     'label'  => 'long label',
-                    'width'  => 300,
+                    'width'  => 3000,
                     'format' => Variable::FORMAT_TYPE_A,
                     'attributes' => [
                         '$@Role' => Variable::ROLE_INPUT,


### PR DESCRIPTION
I'm having issues with really long strings in SPSS 20.

Specifically the variables don't get stitched back together by SPSS resulting in ~20 variables of 255 chars instead of just one.
This PR just has an altered test file, to create an SPSS File that doesn't work properly...