### PR TITLE
This reverted the writeblank optimization. Closes  #46

### DIFF
--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -164,12 +164,11 @@ class Variable extends Record
             }
         }
 
-        // I think we don't need an empty record
-        //$this->writeBlank($buffer, $seg0width);
+        // We need an empty record
+        $this->writeBlank($buffer, $seg0width);
 
         // Write additional segments for very long string variables.
         if (self::isVeryLong($this->width)) {
-            $this->writeBlank($buffer, $seg0width);
             $segmentCount = Utils::widthToSegments($this->width);
             for ($i = 1; $i < $segmentCount; $i++) {
                 $segmentWidth = Utils::segmentAllocWidth($this->width, $i);


### PR DESCRIPTION
This reverted the writeblank optimization, as some software like pspp can fail to read the resulting file. This also closes #46.

**Edit:** This break the test case `WriteMultibyteTest`, because now we write an empty record  and then we write the variable data. So the variable label is moved to the next position.

So, instead of:
 `$this->assertEquals(mb_substr($data['variables'][1]['values'][1], 0, -2, 'UTF-8'), $reader->variables[1]->label);`

we need:
 `$this->assertEquals(mb_substr($data['variables'][1]['values'][1], 0, -2, 'UTF-8'), $reader->variables[2]->label);`