### PR TITLE
Fixed the WriteMultibyteTest test case

### DIFF
--- a/tests/WriteMultibyteTest.php
+++ b/tests/WriteMultibyteTest.php
@@ -46,7 +46,7 @@ class WriteMultibyteTest extends TestCase
         $this->assertEquals($data['variables'][0]['label'], $reader->variables[0]->label);
 
         // Long variable label
-        $this->assertEquals(mb_substr($data['variables'][1]['values'][1], 0, -2, 'UTF-8'), $reader->variables[1]->label);
+        $this->assertEquals(mb_substr($data['variables'][1]['values'][1], 0, -2, 'UTF-8'), $reader->variables[2]->label);
         
         // Long value label
         $this->assertEquals(mb_substr($data['variables'][1]['label'], 0, -2, 'UTF-8'), $reader->valueLabels[0]->labels[0]['label']);


### PR DESCRIPTION
Please not merged this pull yet (see the next comment):

The  WriteMultibyteTest test case was broken in #47, as is was reported in the description of this pull. This only apply the suggested patch to that test case.