### PR TITLE
Fix date writer

### DIFF
--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -201,7 +201,11 @@ class Writer
                 $this->data->matrix[$case][$idx] = $value;
             }
 
-            $nominalIdx += Utils::widthToOcts($var->width);
+            if (Variable::isNumberFormat($var->format)) {
+                $nominalIdx += 1;
+            } else {
+                $nominalIdx += Utils::widthToOcts($var->width);
+            }
         }
 
         $this->header->nominalCaseSize = $nominalIdx;


### PR DESCRIPTION
For numeric values, we only need to increment $nominalIdx by 1. With date having width of 20, Utils::widthToOcts($var->width) returns 3 and $nominalIndex is no longer correctly calculated as it shifts subsequent variables too far.