### PR TITLE
Add support for Character Encoding

### DIFF
--- a/src/Sav/Reader.php
+++ b/src/Sav/Reader.php
@@ -165,7 +165,7 @@ class Reader
             $encode = $this->info[Record\Info\CharacterEncoding::SUBTYPE]->value;
             // If is not set assume the UTF-8 encode.
             $encode = (isset($encode) && !empty($encode)) ? $encode : "UTF-8";
-            $this->_buffer->streamCharset = $encode;
+            $this->_buffer->charset = $encode;
 
             if ($this->_buffer->seek($headerPosition) === 0) {
                 $this->valueLabels = [];

--- a/src/Sav/Reader.php
+++ b/src/Sav/Reader.php
@@ -165,7 +165,7 @@ class Reader
             $encode = $this->info[Record\Info\CharacterEncoding::SUBTYPE]->value;
             // If is not set assume the UTF-8 encode.
             $encode = (isset($encode) && !empty($encode)) ? $encode : "UTF-8";
-            $this->_buffer->charset = $encode;
+            $this->_buffer->streamCharset = $encode;
 
             if ($this->_buffer->seek($headerPosition) === 0) {
                 $this->valueLabels = [];

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -98,7 +98,7 @@ class Writer
         $this->info[Record\Info\LongStringValueLabels::SUBTYPE]   = new Record\Info\LongStringValueLabels();
         $this->info[Record\Info\LongStringMissingValues::SUBTYPE] = new Record\Info\LongStringMissingValues();
 
-        $encode = (isset($data['info']) && isset($data['info']['characterEncoding'])) ? $config['info']['characterEncoding'] : 'UTF-8';
+        $encode = (isset($data['info']) && isset($data['info']['characterEncoding'])) ? $data['info']['characterEncoding'] : 'UTF-8';
         $this->info[Record\Info\CharacterEncoding::SUBTYPE]       = new Record\Info\CharacterEncoding($encode);
         $this->buffer->charset = $encode;
 

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -100,7 +100,7 @@ class Writer
 
         $encode = (isset($data['info']) && isset($data['info']['characterEncoding'])) ? $data['info']['characterEncoding'] : 'UTF-8';
         $this->info[Record\Info\CharacterEncoding::SUBTYPE]       = new Record\Info\CharacterEncoding($encode);
-        $this->buffer->charset = $encode;
+        $this->buffer->streamCharset = $encode;
 
         $this->data = new Record\Data();
 

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -100,7 +100,7 @@ class Writer
 
         $encode = (isset($data['info']) && isset($data['info']['characterEncoding'])) ? $data['info']['characterEncoding'] : 'UTF-8';
         $this->info[Record\Info\CharacterEncoding::SUBTYPE]       = new Record\Info\CharacterEncoding($encode);
-        $this->buffer->streamCharset = $encode;
+        $this->buffer->charset = $encode;
 
         $this->data = new Record\Data();
 

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -97,7 +97,10 @@ class Writer
         $this->info[Record\Info\VariableAttributes::SUBTYPE]      = new Record\Info\VariableAttributes();
         $this->info[Record\Info\LongStringValueLabels::SUBTYPE]   = new Record\Info\LongStringValueLabels();
         $this->info[Record\Info\LongStringMissingValues::SUBTYPE] = new Record\Info\LongStringMissingValues();
-        $this->info[Record\Info\CharacterEncoding::SUBTYPE]       = new Record\Info\CharacterEncoding('UTF-8');
+
+        $encode = (isset($data['info']) && isset($data['info']['characterEncoding'])) ? $config['info']['characterEncoding'] : 'UTF-8';
+        $this->info[Record\Info\CharacterEncoding::SUBTYPE]       = new Record\Info\CharacterEncoding($encode);
+        $this->buffer->charset = $encode;
 
         $this->data = new Record\Data();
 


### PR DESCRIPTION
This add support for Character Encoding, but this solution implies read the body twice.

The CharacterEncoding data should not necessary be set at the beginning of the body. So, any string that is set before found the Character Encoding of the file body it is then not decode. This is why, currently we need to read twice the body, once to find the encode and another to decode the body.