### PR TITLE
Writer: Allow to set the buffer and a custom file.

### DIFF
--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -47,16 +47,28 @@ class Writer
      * Writer constructor.
      *
      * @param array $data
+     * @param Buffer $buffer
      *
      */
-    public function __construct($data = [])
+    public function __construct($data = [], $buffer = null)
     {
-        $this->buffer          = Buffer::factory();
+        $this->buffer          = isset($buffer) ? $buffer : Buffer::factory();
         $this->buffer->context = $this;
 
         if (!empty($data)) {
             $this->write($data);
         }
+    }
+    
+    /**
+     * @param array $data
+     * @param string $file
+     *
+     * @return Writer
+     */
+    public static function createInFile($data = [], $file)
+    {
+        return new self($data, Buffer::factory(fopen($file, 'wb+')));
     }
 
     public function write($data)


### PR DESCRIPTION
This allow to set the buffer and a custom file to the writer, as this is useful when we are creating a big file and the temporal folder is not in the current partition where we need to save the file. Move a big file between partitions is a complex process and also the usage of file_put_contents is not a good idea also as when the file is in the same partition will be duplicate instead of be moved. So, this try to avoid the need of that usage.

Please note that in this case we don' t need to call the save function as the file is saved directly when is create, but if we call it the file need to be save in a different location then.