### PR TITLE
Fix deprecation warnings on PHP 8.1

### DIFF
--- a/src/Sav/Record/Document.php
+++ b/src/Sav/Record/Document.php
@@ -55,6 +55,7 @@ class Document extends Record implements \ArrayAccess
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->lines[$offset]);
@@ -65,6 +66,7 @@ class Document extends Record implements \ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->lines[$offset];
@@ -74,6 +76,7 @@ class Document extends Record implements \ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->lines[$offset] = $value;
@@ -82,6 +85,7 @@ class Document extends Record implements \ArrayAccess
     /**
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->lines[$offset]);

--- a/src/Sav/Record/Info.php
+++ b/src/Sav/Record/Info.php
@@ -52,6 +52,7 @@ class Info extends Record implements \ArrayAccess
      *
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->data[$offset]);
@@ -62,6 +63,7 @@ class Info extends Record implements \ArrayAccess
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->data[$offset];
@@ -71,6 +73,7 @@ class Info extends Record implements \ArrayAccess
      * @param mixed $offset
      * @param mixed $value
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if (null === $offset) {
@@ -83,6 +86,7 @@ class Info extends Record implements \ArrayAccess
     /**
      * @param mixed $offset
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->data[$offset]);


### PR DESCRIPTION
If running on PHP 8.1, we would get deprecation messages like

```
PHP Deprecated:  Return type of SPSS\Sav\Record\Info::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in {...}/vendor/tiamo/spss/src/Sav/Record/Info.php on line 55
```

By adding a `#[\ReturnTypeWillChange]` attribute, we remain compatible with PHP 5.6+
but don't get deprecation warnings on 8.1.