### PR TITLE
Handled the stream charset and the system charset gobally.

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -17,7 +17,12 @@ class Buffer
     /**
      * @var string
      */
-    public $charset;
+    public $streamCharset = 'UTF-8';
+
+    /**
+     * @var string
+     */
+    public $systemCharset = 'UTF-8';
 
     /**
      * @var resource
@@ -158,21 +163,18 @@ class Buffer
     /**
      * @param int  $length
      * @param int  $round
-     * @param null $charset
      *
      * @return false|string
      */
-    public function readString($length, $round = 0, $charset = null)
+    public function readString($length, $round = 0)
     {
         if ($bytes = $this->readBytes($length)) {
             if ($round !== 0) {
                 $this->skip(Utils::roundUp($length, $round) - $length);
             }
             $str = Utils::bytesToString($bytes);
-            if ($charset) {
-                $str = mb_convert_encoding($str, 'utf8', $charset);
-            } elseif (!empty($this->charset)) {
-                $str = mb_convert_encoding($str, 'utf8', $this->charset);
+            if (isset($str) && (strtolower($this->streamCharset) != strtolower($this->systemCharset))) {
+                $str = mb_convert_encoding($str, $this->systemCharset, $this->streamCharset);
             }
 
             return $str;
@@ -214,16 +216,13 @@ class Buffer
     /**
      * @param $data
      * @param int|string $length
-     * @param null       $charset
      *
      * @return false|int
      */
-    public function writeString($data, $length = '*', $charset = null)
+    public function writeString($data, $length = '*')
     {
-        if ($charset) {
-            $data = mb_convert_encoding($data, 'utf8', $charset);
-        } elseif (!empty($this->charset)) {
-            $data = mb_convert_encoding($data, 'utf8', $this->charset);
+        if (strtolower($this->streamCharset) != strtolower($this->systemCharset)) {
+            $data = mb_convert_encoding($data, $this->streamCharset, $this->systemCharset);
         }
 
         return $this->write(pack('A' . $length, $data));


### PR DESCRIPTION
The Buffer charset is not used currently, but is defined in a mixed way. For read an string, it assumed the file is in a charset but we want the result (system charset) in UTF-8 and for write an string, it assumed we are used a charset (a system charset)  but we always want the result in a UTF-8 file.

The true is that both thing are possibles and wanted for read and for write a file. So, that change make it possible, because do not hardcode any of that possible behaviors without matter if is for read or for write. 

This also remove the charset parameter of the funtion and use only the global one. It doesn't really make much sense for one text to have one encoding, while another text from the same source has another encoding. Therefore, establishing the encoding globally once should be enough for a normal usage.