### PR TITLE
Improve the required bytes calculation.

### DIFF
--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -173,7 +173,7 @@ class Buffer
             $charsetFrom = isset($this->charset) ? $this->charset : mb_internal_encoding();
             $charsetTo = isset($charset) ? $charset : mb_internal_encoding();
             if (isset($str) && (strtolower($charsetFrom) != strtolower($charsetTo))) {
-                $str = mb_convert_encoding($str, $charsetTo, $this->charset);
+                $str = mb_convert_encoding($str, $charsetTo, $charsetFrom);
             }
 
             return $str;
@@ -218,13 +218,15 @@ class Buffer
      *
      * @return int
      */
-    public function lengthBytes($data, $maxLength = null)
+    public function lengthBytes($data, $maxLength = null, $charset = null)
     {
-        if (strtolower($this->streamCharset) != strtolower($this->systemCharset)) {
-            $data = mb_convert_encoding($data, $this->streamCharset, $this->systemCharset);
+        $charsetTo = isset($this->charset) ? $this->charset : mb_internal_encoding();
+        $charsetFrom = isset($charset) ? $charset : mb_internal_encoding();
+        if (isset($data) && (strtolower($charsetTo) != strtolower($charsetFrom))) {
+            $data = mb_convert_encoding($data, $charsetTo, $charsetFrom);
         }
-        if (isset($maxLength)) {
-            $data = mb_strcut($data, 0, $maxLength, $this->streamCharset);
+        if (isset($data) && isset($maxLength)) {
+            $data = mb_strcut($data, 0, $maxLength, $charsetTo);
         }
         return \strlen($data);
     }
@@ -244,7 +246,7 @@ class Buffer
             $data = mb_convert_encoding($data, $charsetTo, $charsetFrom);
         }
         if (isset($length) && ($length != '*')) {
-            $data = mb_strcut($data, 0, $length, $this->charset);
+            $data = mb_strcut($data, 0, $length, $charsetTo);
         }
         return $this->write(pack('A' . $length, $data));
     }

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -213,7 +213,22 @@ class Buffer
     }
 
     /**
-     * @param $data
+     * @param string $data
+     * @param int $maxLength
+     *
+     * @return int
+     */
+    public function lengthBytes($data, $maxLength)
+    {
+        if (strtolower($this->streamCharset) != strtolower($this->systemCharset)) {
+            $data = mb_convert_encoding($data, $this->streamCharset, $this->systemCharset);
+        }
+        $data = mb_strcut($data, 0, $maxLength, $this->streamCharset);
+        return \strlen($data);
+    }
+
+    /**
+     * @param string $data
      * @param int|string $length
      * @param null       $charset
      *
@@ -226,7 +241,9 @@ class Buffer
         if (isset($data) && (strtolower($charsetFrom) != strtolower($charsetTo))) {
             $data = mb_convert_encoding($data, $charsetTo, $charsetFrom);
         }
-        //file_put_contents("/var/encuestas/test.txt", "To: " . $charsetTo . " FROM:" . $charsetFrom . "\n", FILE_APPEND | LOCK_EX);
+        if (isset($length) && ($length != '*')) {
+            $data = mb_strcut($data, 0, $length, $this->charset);
+        }
         return $this->write(pack('A' . $length, $data));
     }
 

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -218,12 +218,14 @@ class Buffer
      *
      * @return int
      */
-    public function lengthBytes($data, $maxLength)
+    public function lengthBytes($data, $maxLength = null)
     {
         if (strtolower($this->streamCharset) != strtolower($this->systemCharset)) {
             $data = mb_convert_encoding($data, $this->streamCharset, $this->systemCharset);
         }
-        $data = mb_strcut($data, 0, $maxLength, $this->streamCharset);
+        if (isset($maxLength)) {
+            $data = mb_strcut($data, 0, $maxLength, $this->streamCharset);
+        }
         return \strlen($data);
     }
 

--- a/src/Buffer.php
+++ b/src/Buffer.php
@@ -156,9 +156,9 @@ class Buffer
     }
 
     /**
-     * @param int  $length
-     * @param int  $round
-     * @param null $charset
+     * @param int         $length
+     * @param int         $round
+     * @param null|string $charset
      *
      * @return false|string
      */
@@ -213,8 +213,9 @@ class Buffer
     }
 
     /**
-     * @param string $data
-     * @param int $maxLength
+     * @param string      $data
+     * @param int         $maxLength
+     * @param null|string $charset
      *
      * @return int
      */
@@ -232,9 +233,9 @@ class Buffer
     }
 
     /**
-     * @param string $data
-     * @param int|string $length
-     * @param null       $charset
+     * @param string      $data
+     * @param int|string  $length
+     * @param null|string $charset
      *
      * @return false|int
      */

--- a/src/Sav/Record/Info/LongStringValueLabels.php
+++ b/src/Sav/Record/Info/LongStringValueLabels.php
@@ -45,15 +45,17 @@ class LongStringValueLabels extends Info
                 throw new \InvalidArgumentException('values required');
             }
             $width = (int) $data['width'];
-            $localBuffer->writeInt(mb_strlen($varName));
-            $localBuffer->writeString($varName, mb_strlen($varName));
+            $varLengthBytes = $buffer->lengthBytes($varName);
+            $localBuffer->writeInt($varLengthBytes);
+            $localBuffer->writeString($varName, $varLengthBytes);
             $localBuffer->writeInt($width);
             $localBuffer->writeInt(Utils::is_countable($data['values']) ? \count($data['values']) : 0);
             foreach ($data['values'] as $value => $label) {
                 $localBuffer->writeInt($width);
                 $localBuffer->writeString($value, $width);
-                $localBuffer->writeInt(mb_strlen($label));
-                $localBuffer->writeString($label, mb_strlen($label));
+                $labelLengthBytes = $buffer->lengthBytes($label);
+                $localBuffer->writeInt($labelLengthBytes);
+                $localBuffer->writeString($label, $labelLengthBytes);
             }
         }
 

--- a/src/Sav/Record/Info/VariableAttributes.php
+++ b/src/Sav/Record/Info/VariableAttributes.php
@@ -44,7 +44,7 @@ class VariableAttributes extends Info
 
         if ($lines !== []) {
             $data            = implode('/', $lines);
-            $this->dataCount = mb_strlen($data);
+            $this->dataCount = \strlen($data);
             parent::write($buffer);
             $buffer->writeString($data);
         }

--- a/src/Sav/Record/ValueLabel.php
+++ b/src/Sav/Record/ValueLabel.php
@@ -97,22 +97,16 @@ class ValueLabel extends Record
         $buffer->writeInt(self::TYPE);
         $buffer->writeInt(\count($this->labels));
         foreach ($this->labels as $item) {
-            $labelLength      = min(mb_strlen($item['label']), self::LABEL_MAX_LENGTH);
-            $label            = mb_substr($item['label'], 0, $labelLength);
-            $labelLengthBytes = mb_strlen($label, '8bit');
-            while ($labelLengthBytes > 255) {
-                // Strip one char, can be multiple bytes
-                $label            = mb_substr($label, 0, -1);
-                $labelLengthBytes = mb_strlen($label, '8bit');
-            }
-
+            $labelLengthBytes = $buffer->lengthBytes($item['label'], self::LABEL_MAX_LENGTH);
+            $labelLengthBytesRound = Utils::roundUp($labelLengthBytes + 1, 8) - 1;
+            
             if ($convertToDouble) {
                 $item['value'] = Utils::stringToDouble($item['value']);
             }
 
             $buffer->writeDouble($item['value']);
             $buffer->write(\chr($labelLengthBytes));
-            $buffer->writeString($label, Utils::roundUp($labelLengthBytes + 1, 8) - 1);
+            $buffer->writeString($item['label'], $labelLengthBytesRound);
         }
 
         // Value label variable record.

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -141,17 +141,10 @@ class Variable extends Record
         $buffer->writeString($this->name, 8);
 
         if ($hasLabel) {
-            // Maxlength is 255 bytes, since we write utf8 a char can be multiple bytes
-            $labelLength      = min(mb_strlen($this->label), 255);
-            $label            = mb_substr($this->label, 0, $labelLength);
-            $labelLengthBytes = mb_strlen($label, '8bit');
-            while ($labelLengthBytes > 255) {
-                // Strip one char, can be multiple bytes
-                $label            = mb_substr($label, 0, -1);
-                $labelLengthBytes = mb_strlen($label, '8bit');
-            }
+            $labelLengthBytes = $buffer->lengthBytes($this->label, self::REAL_VLS_CHUNK);
+            $labelLengthBytesRound = Utils::roundUp($labelLengthBytes, 4);
             $buffer->writeInt($labelLengthBytes);
-            $buffer->writeString($label, Utils::roundUp($labelLengthBytes, 4));
+            $buffer->writeString($this->label, $labelLengthBytesRound);
         }
 
         // TODO: test
@@ -222,6 +215,6 @@ class Variable extends Record
             return mb_strtoupper($this->name);
         }
         $sufix = str_pad($str, 2, "_", STR_PAD_LEFT);
-        return mb_strtoupper(mb_substr($this->name.$sufix, 0, 8));
+        return mb_strtoupper(mb_strcut($this->name.$sufix, 0, 8));
     }
 }

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -173,8 +173,7 @@ class Variable extends Record
                 $buffer->writeInt(0); // No missing values
                 $buffer->writeInt($format); // Print format
                 $buffer->writeInt($format); // Write format
-                $buffer->writeString($this->getSegmentName($i - 1), 8);
-
+                $buffer->writeString($this->getSegmentName($buffer, $i - 1), 8);
                 $this->writeBlank($buffer, $segmentWidth);
             }
         }
@@ -204,7 +203,7 @@ class Variable extends Record
      *
      * @return string
      */
-    public function getSegmentName($seg = 0)
+    public function getSegmentName($buffer, $seg = 0)
     {
         // TODO: refactory
         $str = "a";

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -173,7 +173,7 @@ class Variable extends Record
                 $buffer->writeInt(0); // No missing values
                 $buffer->writeInt($format); // Print format
                 $buffer->writeInt($format); // Write format
-                $buffer->writeString($this->getSegmentName($buffer, $i - 1), 8);
+                $buffer->writeString($this->getSegmentName($i - 1), 8);
                 $this->writeBlank($buffer, $segmentWidth);
             }
         }
@@ -203,7 +203,7 @@ class Variable extends Record
      *
      * @return string
      */
-    public function getSegmentName($buffer, $seg = 0)
+    public function getSegmentName($seg = 0)
     {
         // TODO: refactory
         $str = "a";

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -215,6 +215,6 @@ class Variable extends Record
             return mb_strtoupper($this->name);
         }
         $sufix = str_pad($str, 2, "_", STR_PAD_LEFT);
-        return mb_strtoupper(mb_substr($this->name.$sufix, 0, 8));
+        return mb_strtoupper(mb_strcut($this->name.$sufix, 0, 8));
     }
 }

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -141,6 +141,7 @@ class Variable extends Record
         $buffer->writeString($this->name, 8);
 
         if ($hasLabel) {
+            // Maxlength is 255 bytes, since we write utf8 a char can be multiple bytes
             $labelLengthBytes = $buffer->lengthBytes($this->label, self::REAL_VLS_CHUNK);
             $labelLengthBytesRound = Utils::roundUp($labelLengthBytes, 4);
             $buffer->writeInt($labelLengthBytes);
@@ -214,6 +215,6 @@ class Variable extends Record
             return mb_strtoupper($this->name);
         }
         $sufix = str_pad($str, 2, "_", STR_PAD_LEFT);
-        return mb_strtoupper(mb_strcut($this->name.$sufix, 0, 8));
+        return mb_strtoupper(mb_substr($this->name.$sufix, 0, 8));
     }
 }


### PR DESCRIPTION
This improve the calculation of the required bytes of an string that should be stored using a user custom charset. 

The idea is delegate the cut to the buffer that is who really know the final charset of the string in the stream (the sav file). At same time this cut the string using the bytes representation instead of the character length representation of the charset. See [`mb_strcut`](https://www.php.net/manual/en/function.mb-strcut.php) for more details.