### PR TITLE
Fixed MachineFloatingPoint and improve the related Test Class

### DIFF
--- a/src/Sav/Record/Info/MachineFloatingPoint.php
+++ b/src/Sav/Record/Info/MachineFloatingPoint.php
@@ -52,15 +52,15 @@ class MachineFloatingPoint extends Info
 
     public function write(Buffer $buffer)
     {
-        if ($this->sysmis === 0.0) {
+        if (!isset($this->sysmis)) {
             $this->sysmis = -PHP_FLOAT_MAX;
         }
 
-        if ($this->highest === 0.0) {
+        if (!isset($this->highest)) {
             $this->highest = PHP_FLOAT_MAX;
         }
 
-        if ($this->lowest === 0.0) {
+        if (!isset($this->lowest)) {
             $this->lowest = -PHP_FLOAT_MAX;
         }
 

--- a/tests/MachineFloatingPointTest.php
+++ b/tests/MachineFloatingPointTest.php
@@ -24,12 +24,12 @@ class MachineFloatingPointTest extends TestCase
             ],
             [
                 [],
-                // -1.7976931348623E+308 php min double
-                //  1.7976931348623E+308 php max double
+                // -1.7976931348623E+308 php min double -PHP_FLOAT_MAX
+                //  1.7976931348623E+308 php max double PHP_FLOAT_MAX
                 [
-                    'sysmis'  => -1.7976931348623158E+308,
-                    'highest' => 1.7976931348623158E+308,
-                    'lowest'  => -1.7976931348623158E+308,
+                    'sysmis'  => -PHP_FLOAT_MAX,
+                    'highest' =>  PHP_FLOAT_MAX,
+                    'lowest'  => -PHP_FLOAT_MAX,
                 ],
             ],
         ];
@@ -54,10 +54,8 @@ class MachineFloatingPointTest extends TestCase
         $read = MachineFloatingPoint::fill($buffer);
         $this->assertEquals(40, $buffer->position());
         foreach ($expected as $key => $value) {
-            $expected = 0;
-            $actual   = @bcsub($value, $read->{$key});
             $msg      = "Wrong value received for '$key', expected '$value', got '{$read->{$key}}'";
-            $this->assertEquals($expected, $actual, $msg);
+            $this->assertEquals($value, $read->{$key}, $msg);
         }
     }
 }


### PR DESCRIPTION
The `$sysmis`, `$highest` and `$lowest `are unset on the class initialization, so they should not be compare with 0.0, but instead should be asked if they are unset.

The test case for the `MachineFloatingPoint` not need at all the usage of  `bcMatch`, so that usage it can be removed to add more simplicity to the test case.