### PR TITLE
Rewrite regex and add extra check to variable names

### DIFF
--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -59,7 +59,7 @@ class Writer
             $this->write($data);
         }
     }
-    
+
     /**
      * @param array $data
      * @param string $file
@@ -110,10 +110,13 @@ class Writer
                 $var = new Variable($var);
             }
 
-            //if (! preg_match('/^[A-Za-z0-9_]+$/', $var->name)) {
             // UTF-8 and '.' characters could pass here
-            if (!preg_match('/^[A-Za-z0-9_\.\x{4e00}-\x{9fa5}]+$/u', $var->name)) {
+            if (!preg_match('/^(?!#|\$|\.)[\w0-9_.#@$\x{4e00}-\x{9fa5}]+(?<!\.|_)$/u', $var->name)) {
                 throw new \InvalidArgumentException(sprintf('Variable name `%s` contains an illegal character.', $var->name));
+            }
+
+            if (in_array($var->name, ['ALL', 'AND', 'BY', 'EQ', 'GE', 'GT', 'LE', 'LT', 'NE', 'NOT', 'OR', 'TO', 'WITH'])) {
+                throw new \InvalidArgumentException(sprintf('Variable name `%s` is reserved!.', $var->name));
             }
 
             if (empty($var->width)) {

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -101,7 +101,22 @@ class Writer
 
         $this->data = new Record\Data();
 
-        $nominalIdx = 0;
+        $nominalIdx        = 0;
+        $reservedNamesIndex = [
+            'ALL'  => 0,
+            'AND'  => 0,
+            'BY'   => 0,
+            'EQ'   => 0,
+            'GE'   => 0,
+            'GT'   => 0,
+            'LE'   => 0,
+            'LT'   => 0,
+            'NE'   => 0,
+            'NOT'  => 0,
+            'OR'   => 0,
+            'TO'   => 0,
+            'WITH' => 0,
+        ];
 
         /** @var Variable $var */
         // for ($idx = 0; $idx <= $variablesCount; $idx++) {
@@ -116,7 +131,8 @@ class Writer
             }
 
             if (in_array($var->name, ['ALL', 'AND', 'BY', 'EQ', 'GE', 'GT', 'LE', 'LT', 'NE', 'NOT', 'OR', 'TO', 'WITH'])) {
-                throw new \InvalidArgumentException(sprintf('Variable name `%s` is reserved!.', $var->name));
+                $reservedNamesIndex[$var->name]++;
+                $var->name = $var->name . '_' . $reservedNamesIndex[$var->name];
             }
 
             if (empty($var->width)) {

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -102,21 +102,6 @@ class Writer
         $this->data = new Record\Data();
 
         $nominalIdx        = 0;
-        $reservedNamesIndex = [
-            'ALL'  => 0,
-            'AND'  => 0,
-            'BY'   => 0,
-            'EQ'   => 0,
-            'GE'   => 0,
-            'GT'   => 0,
-            'LE'   => 0,
-            'LT'   => 0,
-            'NE'   => 0,
-            'NOT'  => 0,
-            'OR'   => 0,
-            'TO'   => 0,
-            'WITH' => 0,
-        ];
 
         /** @var Variable $var */
         // for ($idx = 0; $idx <= $variablesCount; $idx++) {
@@ -131,8 +116,7 @@ class Writer
             }
 
             if (in_array($var->name, ['ALL', 'AND', 'BY', 'EQ', 'GE', 'GT', 'LE', 'LT', 'NE', 'NOT', 'OR', 'TO', 'WITH'])) {
-                $reservedNamesIndex[$var->name]++;
-                $var->name = $var->name . '_' . $reservedNamesIndex[$var->name];
+                $var->name = \uniqid($var->name);
             }
 
             if (empty($var->width)) {

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -34,11 +34,6 @@ class NamingTest extends TestCase
                     'format' => 1,
                 ],
                 [
-                    'name'   => 'WITH',
-                    'width'  => 16,
-                    'format' => 1,
-                ],
-                [
                     'name'   => 'OR',
                     'format' => 5,
                 ],
@@ -51,9 +46,8 @@ class NamingTest extends TestCase
 
         $reader = Reader::fromString($buffer->getStream())->read();
 
-        $this->assertEquals($data['variables'][0]['name'] . '_' . 1, $reader->info[LongVariableNames::SUBTYPE]['V00001']);
-        $this->assertEquals($data['variables'][1]['name'] . '_' . 2, $reader->info[LongVariableNames::SUBTYPE]['V00002']);
-        $this->assertEquals($data['variables'][2]['name'] . '_' . 1, $reader->info[LongVariableNames::SUBTYPE]['V00003']);
+        $this->assertRegExp('/^' . $data['variables'][0]['name'] . '[\w]{13}$/', $reader->info[LongVariableNames::SUBTYPE]['V00001']);
+        $this->assertRegExp('/^' . $data['variables'][1]['name'] . '[\w]{13}$/', $reader->info[LongVariableNames::SUBTYPE]['V00002']);
     }
 
 

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use SPSS\Sav\Reader;
+use SPSS\Sav\Record\Info\LongVariableNames;
+use SPSS\Sav\Writer;
+use SPSS\Tests\TestCase;
+
+class NamingTest extends TestCase
+{
+    public function test()
+    {
+        $data = [
+            'header'    => [
+                'prodName'     => '@(#) IBM SPSS STATISTICS',
+                'layoutCode'   => 2,
+                'creationDate' => date('d M y'),
+                'creationTime' => date('H:i:s'),
+            ],
+            'variables' => [
+                [
+                    'name'   => 'WITH',
+                    'width'  => 16,
+                    'format' => 1,
+                ],
+                [
+                    'name'   => 'WITH',
+                    'width'  => 16,
+                    'format' => 1,
+                ],
+                [
+                    'name'   => 'OR',
+                    'format' => 5,
+                ],
+            ],
+        ];
+        $writer = new Writer($data);
+
+        $buffer = $writer->getBuffer();
+        $buffer->rewind();
+
+        $reader = Reader::fromString($buffer->getStream())->read();
+
+        $this->assertEquals($data['variables'][0]['name'] . '_' . 1, $reader->info[LongVariableNames::SUBTYPE]['V00001']);
+        $this->assertEquals($data['variables'][1]['name'] . '_' . 2, $reader->info[LongVariableNames::SUBTYPE]['V00002']);
+        $this->assertEquals($data['variables'][2]['name'] . '_' . 1, $reader->info[LongVariableNames::SUBTYPE]['V00003']);
+    }
+}

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -7,7 +7,18 @@ use SPSS\Tests\TestCase;
 
 class NamingTest extends TestCase
 {
-    public function test()
+    public function illegalNameProvider()
+    {
+        return [
+            ['#FOO', ''],
+            ['$FOO', ''],
+            ['.FOO', ''],
+            ['FOO.', ''],
+            ['FOO_', ''],
+        ];
+    }
+
+    public function testReservedNames()
     {
         $data = [
             'header'    => [
@@ -43,5 +54,33 @@ class NamingTest extends TestCase
         $this->assertEquals($data['variables'][0]['name'] . '_' . 1, $reader->info[LongVariableNames::SUBTYPE]['V00001']);
         $this->assertEquals($data['variables'][1]['name'] . '_' . 2, $reader->info[LongVariableNames::SUBTYPE]['V00002']);
         $this->assertEquals($data['variables'][2]['name'] . '_' . 1, $reader->info[LongVariableNames::SUBTYPE]['V00003']);
+    }
+
+
+    /**
+     * @dataProvider illegalNameProvider
+     */
+    public function testIllegalNames($name)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('Variable name `%s` contains an illegal character.', $name));
+
+        $data = [
+            'header'    => [
+                'prodName'     => '@(#) IBM SPSS STATISTICS',
+                'layoutCode'   => 2,
+                'creationDate' => date('d M y'),
+                'creationTime' => date('H:i:s'),
+            ],
+            'variables' => [
+                [
+                    'name'   => $name,
+                    'width'  => 16,
+                    'format' => 1,
+                ],
+            ],
+        ];
+
+        new Writer($data);
     }
 }

--- a/tests/SavRandomReadWriteTest.php
+++ b/tests/SavRandomReadWriteTest.php
@@ -37,7 +37,7 @@ class SavRandomReadWriteTest extends TestCase
         $count = 1; // mt_rand(1, 20);
         for ($i = 0; $i < $count; $i++) {
             $var = $this->generateVariable([
-                    'id'         => $this->generateRandomString(mt_rand(2, 100)),
+                    'id'         => $this->generateRandomString(mt_rand(2, 100)) . 'a',
                     'casesCount' => $header['casesCount'],
                 ]
             );
@@ -50,7 +50,7 @@ class SavRandomReadWriteTest extends TestCase
         $header['casesCount'] = 5;
         for ($i = 0; $i < 100; $i++) {
             $variable = $this->generateVariable([
-                'id'         => $this->generateRandomString(mt_rand(2, 100)),
+                'id'         => $this->generateRandomString(mt_rand(2, 100)) . 'a',
                 'casesCount' => $header['casesCount'],
             ]);
             $header['nominalCaseSize'] = Utils::widthToOcts($variable['width']);


### PR DESCRIPTION
Currently the regex in the Writer class does not follow the SPSS naming rules. This should ensure that the rules are actually followed.

https://www.ibm.com/docs/en/spss-statistics/28.0.0?topic=SSLVMB_28.0.0/spss/base/syn_variables_variable_names.htm