### PR TITLE
Fix very long string variable.

### DIFF
--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -176,15 +176,11 @@ class Variable extends Record
                 $format       = Utils::bytesToInt([0, 1, max($segmentWidth, 1), 0]);
                 $buffer->writeInt(self::TYPE);
                 $buffer->writeInt($segmentWidth);
-                $buffer->writeInt($hasLabel); // No variable label
+                $buffer->writeInt(0); // No variable label
                 $buffer->writeInt(0); // No missing values
                 $buffer->writeInt($format); // Print format
                 $buffer->writeInt($format); // Write format
                 $buffer->writeString($this->getSegmentName($i - 1), 8);
-                if ($hasLabel) {
-                    $buffer->writeInt($labelLengthBytes);
-                    $buffer->writeString($label, Utils::roundUp($labelLengthBytes, 4));
-                }
 
                 $this->writeBlank($buffer, $segmentWidth);
             }

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -218,10 +218,10 @@ class Variable extends Record
     public function getSegmentName($seg = 0)
     {
         // TODO: refactory
-        $name = $this->name;
-        $name = mb_substr($name, 0, 6);
-        $name .= $seg;
-
-        return mb_strtoupper($name);
-    }
+        $str = "a";
+        for ($i = 0; $i < $seg; $i++) {
+            ++$str; 
+        }
+        return mb_strtoupper($this->name."_".$str);      
+    } 
 }

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -222,6 +222,10 @@ class Variable extends Record
         for ($i = 0; $i < $seg; $i++) {
             ++$str;
         }
-        return mb_strtoupper(mb_strcut($this->name."_".$str, 0, 64));
+        if (($this->name[0] === 'V') && is_numeric(mb_substr($this->name, 1))) {
+            return mb_strtoupper($this->name);
+        }
+        $sufix = str_pad($str, 2, "_", STR_PAD_LEFT);
+        return mb_strtoupper(mb_substr($this->name.$sufix, 0, 8));
     }
 }

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -220,8 +220,8 @@ class Variable extends Record
         // TODO: refactory
         $str = "a";
         for ($i = 0; $i < $seg; $i++) {
-            ++$str; 
+            ++$str;
         }
-        return mb_strtoupper($this->name."_".$str);      
-    } 
+        return mb_strtoupper(mb_strcut($this->name."_".$str, 0, 64));
+    }
 }

--- a/src/Sav/Record/Variable.php
+++ b/src/Sav/Record/Variable.php
@@ -169,7 +169,7 @@ class Variable extends Record
         $this->writeBlank($buffer, $seg0width);
 
         // Write additional segments for very long string variables.
-        if (self::isVeryLong($this->width) !== 0) {
+        if (self::isVeryLong($this->width) !== false) {
             $segmentCount = Utils::widthToSegments($this->width);
             for ($i = 1; $i < $segmentCount; $i++) {
                 $segmentWidth = Utils::segmentAllocWidth($this->width, $i);

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -124,6 +124,7 @@ class Writer
         $this->info[Record\Info\MachineInteger::SUBTYPE]->characterCode = $chCode;
         $this->data = new Record\Data();
         $nominalIdx = 0;
+        $shortVarsSufix = array();
 
         /** @var Variable $var */
         // for ($idx = 0; $idx <= $variablesCount; $idx++) {
@@ -148,8 +149,10 @@ class Writer
             $variable = new Record\Variable();
 
             // TODO: refactory - keep 7 positions so we can add after that for 100 very long string segments
-            $variable->name  = (Record\Variable::isVeryLong($var->width) !== false) ?
-                               mb_strtoupper($var->name) : 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
+            $sufix = mb_strtoupper(mb_substr($var->name, 0, min(mb_strlen($var->name), 5)));
+            $variable->name  = ((Record\Variable::isVeryLong($var->width) !== false) && (!in_array($sufix, $shortVarsSufix))) ?
+                               $sufix : 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
+            array_push($shortVarsSufix, $sufix);
             $variable->width = Variable::FORMAT_TYPE_A === $var->format ? $var->width : 0;
 
             $variable->label = $var->label;

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -124,7 +124,7 @@ class Writer
         $this->info[Record\Info\MachineInteger::SUBTYPE]->characterCode = $chCode;
         $this->data = new Record\Data();
         $nominalIdx = 0;
-        $shortVarsSufix = array();
+        $shortVarsPrefix = array();
 
         /** @var Variable $var */
         // for ($idx = 0; $idx <= $variablesCount; $idx++) {
@@ -149,10 +149,10 @@ class Writer
             $variable = new Record\Variable();
 
             // TODO: refactory - keep 7 positions so we can add after that for 100 very long string segments
-            $sufix = mb_strtoupper(mb_substr($var->name, 0, min(mb_strlen($var->name), 5)));
-            $variable->name  = ((Record\Variable::isVeryLong($var->width) !== false) && (!in_array($sufix, $shortVarsSufix))) ?
-                               $sufix : 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
-            array_push($shortVarsSufix, $sufix);
+            $prefix = mb_strtoupper(mb_substr($var->name, 0, min(mb_strlen($var->name), 5)));
+            $variable->name  = ((Record\Variable::isVeryLong($var->width) !== false) && (!in_array($prefix, $shortVarsPrefix))) ?
+                               $prefix : 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
+            array_push($shortVarsPrefix, $prefix);
             $variable->width = Variable::FORMAT_TYPE_A === $var->format ? $var->width : 0;
 
             $variable->label = $var->label;

--- a/src/Sav/Writer.php
+++ b/src/Sav/Writer.php
@@ -148,7 +148,8 @@ class Writer
             $variable = new Record\Variable();
 
             // TODO: refactory - keep 7 positions so we can add after that for 100 very long string segments
-            $variable->name  = 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
+            $variable->name  = (Record\Variable::isVeryLong($var->width) !== false) ?
+                               mb_strtoupper($var->name) : 'V' . str_pad($idx + 1, 5, 0, STR_PAD_LEFT);
             $variable->width = Variable::FORMAT_TYPE_A === $var->format ? $var->width : 0;
 
             $variable->label = $var->label;


### PR DESCRIPTION
When writing a variable that can store a very long string, SPSS requires that the short name of each variable segment begin with at least the first five characters of the long name, or that all the short names of the variable segments be the same. However, PSPP does not accept this latter option and, if it encounters a file like this, it will display a warning. To avoid this, it is best to use the first option. However, this may not be possible because another variable may already exist whose first five characters of the name match those of the current one. In this case, we must use the latter option, even though PSPP will display a warning. But [what can we do](https://git.savannah.gnu.org/cgit/pspp.git/tree/src/data/pc+-file-reader.c#n869)?

In addition to trying to meet the PSPP's requirements, we will concatenate a suffix to the variable, using the 26-adic notation, just as [PSPP does](https://git.savannah.gnu.org/cgit/pspp.git/tree/src/libpspp/str.c#n262).