### PR TITLE
Fixed the valuelabels and a code maintenance

### DIFF
--- a/src/Sav/Reader.php
+++ b/src/Sav/Reader.php
@@ -81,7 +81,7 @@ class Reader
                 case Record\Variable::TYPE:
                     $variable               = Record\Variable::fill($this->_buffer);
                     $variable->realPosition = $posVar;
-                    $this->variables[]             = $variable;
+                    $this->variables[]      = $variable;
                     $posVar++;
                     break;
                 case Record\ValueLabel::TYPE:
@@ -213,7 +213,7 @@ class Reader
 
         return $this;
     }
-    
+
     /**
      * @return booleam
      */
@@ -247,6 +247,14 @@ class Reader
         }
 
         return false;
+    }
+
+    /**
+     * @return int
+     */
+    public function getNumberOfCases()
+    {
+        return $this->_buffer->context->header->casesCount;
     }
 
     /**

--- a/src/Sav/Record/ValueLabel.php
+++ b/src/Sav/Record/ValueLabel.php
@@ -70,20 +70,21 @@ class ValueLabel extends Record
 
         // Number of variables that the associated value labels from the value label record are to be applied.
         $varCount = $buffer->readInt();
+        $decodeShortVar = false;
         for ($i = 0; $i < $varCount; $i++) {
             $varIndex = $buffer->readInt() - 1;
-
-            // Decode values for short variables
-            if (isset($this->variables[$varIndex])) {
-                $varWidth = $this->variables[$varIndex]->width;
-                if ($varWidth > 0) {
-                    foreach ($this->labels as $labelIdx => $label) {
-                        $this->labels[$labelIdx]['value'] = rtrim(Utils::doubleToString($label['value']));
-                    }
-                }
-            }
-
             $this->indexes[] = $varIndex;
+
+            if (isset($this->variables[$varIndex]) && ($this->variables[$varIndex]->width > 0)) {
+                $decodeShortVar = true;
+            }
+        }
+
+        // Decode values for short variables
+        if ($decodeShortVar) {
+            foreach ($this->labels as $labelIdx => $label) {
+                $this->labels[$labelIdx]['value'] = rtrim(Utils::doubleToString($label['value']));
+            }
         }
     }
 

--- a/tests/MachineFloatingPointTest.php
+++ b/tests/MachineFloatingPointTest.php
@@ -25,7 +25,7 @@ class MachineFloatingPointTest extends TestCase
             [
                 [],
                 // -1.7976931348623E+308 php min double -PHP_FLOAT_MAX
-                //  1.7976931348623E+308 php max double PHP_FLOAT_MAX
+                //  1.7976931348623E+308 php max double  PHP_FLOAT_MAX
                 [
                     'sysmis'  => -PHP_FLOAT_MAX,
                     'highest' =>  PHP_FLOAT_MAX,

--- a/tests/NamingTest.php
+++ b/tests/NamingTest.php
@@ -50,7 +50,6 @@ class NamingTest extends TestCase
         $this->assertRegExp('/^' . $data['variables'][1]['name'] . '[\w]{13}$/', $reader->info[LongVariableNames::SUBTYPE]['V00002']);
     }
 
-
     /**
      * @dataProvider illegalNameProvider
      */

--- a/tests/WriteMultibyteTest.php
+++ b/tests/WriteMultibyteTest.php
@@ -12,7 +12,7 @@ class WriteMultibyteTest extends TestCase
     public function testMultiByteLabel()
     {
         $data = [
-            'header'    => [
+            'header' => [
                 'prodName'     => '@(#) IBM SPSS STATISTICS',
                 'layoutCode'   => 2,
                 'creationDate' => date('d M y'),
@@ -61,7 +61,7 @@ class WriteMultibyteTest extends TestCase
     public function testChinese()
     {
         $input = [
-            'header'    => [
+            'header' => [
                 'prodName'     => '@(#) IBM SPSS STATISTICS 64-bit Macintosh 23.0.0.0',
                 'creationDate' => '05 Oct 18',
                 'creationTime' => '01:36:53',
@@ -128,7 +128,7 @@ class WriteMultibyteTest extends TestCase
     public function testMultiByteVariableName()
     {
         $data = [
-            'header'    => [
+            'header' => [
                 'prodName'     => '@(#) IBM SPSS STATISTICS',
                 'layoutCode'   => 2,
                 'creationDate' => date('d M y'),
@@ -157,7 +157,5 @@ class WriteMultibyteTest extends TestCase
         $this->assertEquals($data['variables'][0]['name'], $reader->info[LongVariableNames::SUBTYPE]['V00001']);
         // Long variable name
         $this->assertEquals($data['variables'][1]['name'], $reader->info[LongVariableNames::SUBTYPE]['V00002']);
-
     }
-
 }


### PR DESCRIPTION
Code quality has been improved and a bug where valuelabels were being read multiple times has been fixed. Reads the same value labels more than one time means that the buffer is moved forwards when it should not.