### PR TITLE
Fix the compression and the non-compression, both are broken.

### DIFF
--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -493,7 +493,7 @@ class Data extends Record
                                 $this->dataBuffer->writeString($val, 8);
                             }
                         } else {
-                            $this->dataBuffer->writeString($val, 8);
+                            $buffer->writeString($val, 8);
                         }
                         $offset += $chunkSize;
                     }

--- a/src/Sav/Record/Data.php
+++ b/src/Sav/Record/Data.php
@@ -464,7 +464,7 @@ class Data extends Record
                     $buffer->writeDouble($value);
                 } elseif ($value === $sysmis || '' === $value) {
                     $this->writeOpcode($buffer, self::OPCODE_SYSMISS);
-                } elseif ($value >= 1 - $bias && $value <= 251 - $bias && $value === (int) $value) {
+                } elseif ($value >= 1 - $bias && $value <= 251 - $bias && (float) $value === (float) (int) $value) {
                     $this->writeOpcode($buffer, $value + $bias);
                 } else {
                     $this->writeOpcode($buffer, self::OPCODE_RAW_DATA);


### PR DESCRIPTION
Currently, the compression doesn't compress a file to its full potential. After comparing the generated file with the same file generated by pspp (opening one generated by the library and then saving it with psps), the difference is noticeable.

Furthermore, if the file isn't compressed (compression = 0), the library currently generates a corrupted file.

This fix corrects both of these issues.